### PR TITLE
Add `sin.term.<grey|red|green|orange|blue|purple>` functions + Add `sin.fs.<md5|symlink>` functions

### DIFF
--- a/src/sin/fs.py
+++ b/src/sin/fs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+'''`sin.fs` offers helpers for filesystem operations.'''
+
+# Copyright © 2021,2023 Lénaïc Bagnères, lenaicb@singularity.fr
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import hashlib
+
+
+def md5(path):
+    '''Compute the md5 of the file `path`.'''
+    m = hashlib.md5()
+    with open(path, 'rb') as f:
+        while True:
+            buf = f.read(2048)
+            if not buf:
+                break
+            m.update(buf)
+    return m.hexdigest()
+
+
+def symlink(src, dest):
+    '''
+    Create the symlink `src` -> `dest`.
+
+    If destination already exists, this function does nothing.
+    '''
+    if os.name == 'posix':
+        try:
+            os.symlink(os.path.abspath(src), dest)
+        except FileExistsError:
+            pass
+    else:
+        raise NotImplementedError(
+            'sin.fs.symlink is not implemented for your OS (' + os.name + ')')

--- a/src/sin/term.py
+++ b/src/sin/term.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+'''`sin.term` offers colored texts for terminals.'''
+
+# Copyright © 2021,2023 Lénaïc Bagnères, lenaicb@singularity.fr
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def grey(s):
+    '''Return the string `s` with grey color code (for VT100 terminals).'''
+    return '\033[90m' + s + '\033[0m'
+
+
+def red(s):
+    '''Return the string `s` with grey color code (for VT100 terminals).'''
+    return '\033[91m' + s + '\033[0m'
+
+
+def green(s):
+    '''Return the string `s` with grey color code (for VT100 terminals).'''
+    return '\033[92m' + s + '\033[0m'
+
+
+def orange(s):
+    '''Return the string `s` with grey color code (for VT100 terminals).'''
+    return '\033[93m' + s + '\033[0m'
+
+
+def blue(s):
+    '''Return the string `s` with grey color code (for VT100 terminals).'''
+    return '\033[94m' + s + '\033[0m'
+
+
+def purple(s):
+    '''Return the string `s` with grey color code (for VT100 terminal).'''
+    return '\033[95m' + s + '\033[0m'

--- a/tests/fs.py
+++ b/tests/fs.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright © 2021,2023 Lénaïc Bagnères, lenaicb@singularity.fr
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import sys
+
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append('../src')
+import sin.fs  # nopep8
+import sin.term  # nopep8
+
+TEST_FILE_PATH = '_test_file'
+
+
+def create_test_file():
+    '''Create the `TEST_FILE_PATH` file'''
+    with open(TEST_FILE_PATH, 'w') as f:
+        f.write('Temporary file to test sin/fs.py')
+
+
+def remove_test_file():
+    '''Remove the `TEST_FILE_PATH` file'''
+    os.remove(TEST_FILE_PATH)
+
+
+def test_sin_fs_md5():
+    '''Test the `sin.fs.md5` function'''
+    create_test_file()
+    assert sin.fs.md5(TEST_FILE_PATH) == 'd1abc9789a534a4cd2f469c7a782b690'
+    remove_test_file()
+
+
+def test_sin_fs_symlink():
+    '''Test the `sin.fs.symlink` function'''
+    create_test_file()
+    symlink_path = TEST_FILE_PATH + '_symlink'
+    sin.fs.symlink(TEST_FILE_PATH, symlink_path)
+    assert os.path.islink(symlink_path)
+    assert sin.fs.md5(symlink_path) == sin.fs.md5(symlink_path)
+    os.remove(symlink_path)
+    remove_test_file()

--- a/tests/term.py
+++ b/tests/term.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright © 2021,2023 Lénaïc Bagnères, lenaicb@singularity.fr
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import sys
+
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append('../src')
+import sin.term  # nopep8
+
+
+def test_sin_term():
+    '''Test the `sin.term.*` functions'''
+    print(sin.term.grey('Grey text'))
+    print(sin.term.red('Red text'))
+    print(sin.term.green('Green text'))
+    print(sin.term.orange('Orange text'))
+    print(sin.term.blue('Blue text'))
+    print(sin.term.purple('Purple text'))


### PR DESCRIPTION
Changes:
- Start `sin.term.*` to display colors in terminals
- Add `sin.fs.md5`
- Start `sin.fs.symlink`