### PR TITLE
ci: Add `debian<10|11|12|13>-<amd64|i386|arm64|armhf|ppc64el>` and `raspios<11|12>-<arm64|armhf>` and `macos<13|14>-amd64`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,56 @@
 name: ci
+
 on:
   pull_request:
+
 jobs:
-  macos:
+
+  debian-10-11:
     continue-on-error: true
-    runs-on: [ self-hosted, "macOS" ]
-    name: macOS
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['debian10-amd64-sse2', 'debian11-amd64-sse2',
+             'debian10-i386-sse2', 'debian11-i386-sse2',
+             'debian10-arm64-asimd', 'debian11-arm64-asimd',
+             'debian10-armhf-neon', 'debian11-armhf-neon',
+             'debian10-ppc64el-vmx', 'debian11-ppc64el-vmx',
+             'raspios11-arm64',
+             'raspios11-armhf']
+    runs-on: [ self-hosted, "${{matrix.os}}" ]
+    name: ${{matrix.os}}
     steps:
       - name: Clean
         run: rm -rf *
       - name: Clone sin-python
         uses: actions/checkout@v3
-        with:
-          repository: 'sin-is-nsimd/sin-python'
-          path: 'sin-python'
-      - name: venv setup
-        run: |
-          cd sin-python
-          python3 -m venv venv
-          source venv/bin/activate
-          pip install pytest
+      - name: Python version
+        run: python3 --version
       - name: Tests
-        shell: bash
-        run: | 
-          cd sin-python
-          source venv/bin/activate
-          pytest tests/*.py
+        run: pytest-3 tests/*.py
+
+  unix:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['debian12-amd64-sse2', 'debian13-amd64-sse2',
+             'debian12-i386-sse2', 'debian13-i386-sse2',
+             'debian12-arm64-asimd', 'debian13-arm64-asimd',
+             'debian12-armhf-neon', 'debian13-armhf-neon',
+             'debian12-ppc64el-vmx', 'debian13-ppc64el-vmx',
+             'raspios12-arm64',
+             'raspios12-armhf-cpu',
+             'macos13-amd64-avx2', 'macos14-amd64-avx2',
+             'macos14-arm64-asimd', 'macos14-arm64-asimd']
+    runs-on: [ self-hosted, "${{matrix.os}}" ]
+    name: ${{matrix.os}}
+    steps:
+      - name: Clean
+        run: rm -rf *
+      - name: Clone sin-python
+        uses: actions/checkout@v3
+      - name: Python version
+        run: python3 --version
+      - name: Tests
+        run: pytest tests/*.py

--- a/src/sin/fs.py
+++ b/src/sin/fs.py
@@ -24,8 +24,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any
-from collections.abc import Generator
+from typing import Any, Generator
 import contextlib
 import hashlib
 import os


### PR DESCRIPTION
Changes:
- Add CI on `debian<10|11|12|13>-<amd64|i386|arm64|armhf|ppc64el>`
- Add CI on `raspios<11|12>-<arm64|armhf>`
- Add CI on `macos<13|14>-amd64`